### PR TITLE
Exclude mkdocs.yaml from pre-commit yaml checking as a workaround

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,7 +8,7 @@ repos:
       - id: end-of-file-fixer
       - id: check-toml
       - id: check-yaml
-        exclude: mkdocs.yml
+        exclude: mkdocs.yml  # See https://github.com/readthedocs/readthedocs.org/issues/6889
       - id: check-added-large-files
       - id: detect-private-key
   - repo: https://github.com/psf/black

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,6 +8,7 @@ repos:
       - id: end-of-file-fixer
       - id: check-toml
       - id: check-yaml
+        exclude: mkdocs.yml
       - id: check-added-large-files
       - id: detect-private-key
   - repo: https://github.com/psf/black


### PR DESCRIPTION
closes #37 